### PR TITLE
Fixed undefined behavior (shift-negative-value)

### DIFF
--- a/lib/Target/Hexagon/HexagonLDBackend.h
+++ b/lib/Target/Hexagon/HexagonLDBackend.h
@@ -157,7 +157,7 @@ class HexagonLDBackend : public GNULDBackend {
   void doCreateProgramHdrs(Module& pModule);
 
   /// maxFwdBranchOffset
-  int64_t maxFwdBranchOffset() const { return ~(~0 << 6); }
+  int64_t maxFwdBranchOffset() const { return ~(~0U << 6); }
 
   virtual void setGOTSectionSize(IRBuilder& pBuilder);
 


### PR DESCRIPTION
This is needed for newer versions of clang:

```
In file included from Target/Hexagon/HexagonAbsoluteStub.cpp:11:
Target/Hexagon/HexagonLDBackend.h:160:52: error: shifting a negative signed value is undefined [-Werror,-Wshift-negative-value]
  int64_t maxFwdBranchOffset() const { return ~(~0 << 6); }
                                                ~~ ^
1 error generated.
```
